### PR TITLE
#4 - [Feat] 숙소 리스트 조회 API 구현

### DIFF
--- a/airbnb/build.gradle
+++ b/airbnb/build.gradle
@@ -1,38 +1,37 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.2.5'
-	id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+    id 'org.springframework.boot' version '3.2.5'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'com.sopt'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-
-
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.3'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/airbnb/src/main/java/com/sopt/airbnb/controller/roomController.java
+++ b/airbnb/src/main/java/com/sopt/airbnb/controller/roomController.java
@@ -1,0 +1,22 @@
+package com.sopt.airbnb.controller;
+
+import com.sopt.airbnb.service.RoomService;
+import com.sopt.airbnb.service.dto.RoomListDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/rooms")
+@RequiredArgsConstructor
+public class roomController {
+
+    private final RoomService roomService;
+
+    @GetMapping
+    public ResponseEntity<RoomListDto> getRoomList() {
+        return ResponseEntity.ok(roomService.findRoomList());
+    }
+}

--- a/airbnb/src/main/java/com/sopt/airbnb/domain/Room.java
+++ b/airbnb/src/main/java/com/sopt/airbnb/domain/Room.java
@@ -1,0 +1,96 @@
+package com.sopt.airbnb.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.math.BigDecimal;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Room {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "roomid")
+    private Long roomId;
+
+    @Column(name = "roomimage", nullable = false, length = 200)
+    private String roomImage;
+
+    @Column(name = "roomlocation", nullable = false, length = 50)
+    private String roomLocation;
+
+    @Column(name = "roomrating", nullable = false, precision = 3, scale = 2)
+    private BigDecimal roomRating;
+
+    @Column(name = "currentdistance", nullable = false, length = 50)
+    private String currentDistance;
+
+    @Column(name = "recommendeddates", nullable = false, length = 30)
+    private String recommendedDates;
+
+    @Column(name = "guestreview", nullable = false, length = 30)
+    private String guestReview;
+
+    @Column(name = "roomprice", nullable = false, length = 30)
+    private String roomPrice;
+
+    @Column(name = "issuperhost", nullable = false)
+    private Boolean isSuperHost;
+
+    @Column(name = "iswishlist", nullable = false)
+    private Boolean isWishList;
+
+    @Builder
+    public Room(
+            String roomImage,
+            String roomLocation,
+            BigDecimal roomRating,
+            String currentDistance,
+            String recommendedDates,
+            String guestReview,
+            String roomPrice,
+            Boolean isSuperHost,
+            Boolean isWishList
+    ) {
+        this.roomImage = roomImage;
+        this.roomLocation = roomLocation;
+        this.roomRating = roomRating;
+        this.currentDistance = currentDistance;
+        this.recommendedDates = recommendedDates;
+        this.guestReview = guestReview;
+        this.roomPrice = roomPrice;
+        this.isSuperHost = isSuperHost;
+        this.isWishList = isWishList;
+    }
+
+    public static Room create(
+            String roomImage,
+            String roomLocation,
+            BigDecimal roomRating,
+            String currentDistance,
+            String recommendedDates,
+            String guestReview,
+            String roomPrice,
+            Boolean isSuperHost,
+            Boolean isWishList
+    ) {
+        return Room.builder()
+                .roomImage(roomImage)
+                .roomLocation(roomLocation)
+                .roomRating(roomRating)
+                .currentDistance(currentDistance)
+                .recommendedDates(recommendedDates)
+                .guestReview(guestReview)
+                .roomPrice(roomPrice)
+                .isSuperHost(isSuperHost)
+                .isWishList(isWishList)
+                .build();
+    }
+}

--- a/airbnb/src/main/java/com/sopt/airbnb/repository/RoomRepository.java
+++ b/airbnb/src/main/java/com/sopt/airbnb/repository/RoomRepository.java
@@ -1,0 +1,7 @@
+package com.sopt.airbnb.repository;
+
+import com.sopt.airbnb.domain.Room;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomRepository extends JpaRepository<Room, Long> {
+}

--- a/airbnb/src/main/java/com/sopt/airbnb/service/RoomService.java
+++ b/airbnb/src/main/java/com/sopt/airbnb/service/RoomService.java
@@ -1,0 +1,17 @@
+package com.sopt.airbnb.service;
+
+import com.sopt.airbnb.repository.RoomRepository;
+import com.sopt.airbnb.service.dto.RoomListDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RoomService {
+
+    private final RoomRepository roomRepository;
+
+    public RoomListDto findRoomList() {
+        return RoomListDto.create(roomRepository.findAll());
+    }
+}

--- a/airbnb/src/main/java/com/sopt/airbnb/service/dto/RoomListDto.java
+++ b/airbnb/src/main/java/com/sopt/airbnb/service/dto/RoomListDto.java
@@ -1,0 +1,15 @@
+package com.sopt.airbnb.service.dto;
+
+import com.sopt.airbnb.domain.Room;
+import java.util.Collections;
+import java.util.List;
+
+public record RoomListDto(
+        List<Room> rooms
+) {
+    public static RoomListDto create(List<Room> originalRooms) {
+        List<Room> unmodifiableRooms = Collections.unmodifiableList(originalRooms);
+
+        return new RoomListDto(unmodifiableRooms);
+    }
+}


### PR DESCRIPTION
# 🔥Pull requests

## ⛳️ 작업한 브랜치
- Resolved: #4 

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
숙소 리스트 조회 API를 구현했습니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

<img width="1792" alt="image" src="https://github.com/NOW-SOPT-CDSP-TEAM-WEB2/Server/assets/81475587/76ea52fa-30ef-4f8a-81a6-2e7b08886919">

후딱 구현하고 붙이기 위해서 일단 로컬 DB에서만 문제 없이 돌아가는지 확인해봤습니다.
내일은 진짜진짜 스웨거도 달고 https 배포까지 하겠습니다 ..~ 깃 꼬인 거 푸느라 시간이 .. 어흑

**보고 문제 없는 것 같으면 바로 머지해서 쓰시면 될 것 같습니다 ~!**